### PR TITLE
Fix severity level for 'critical'

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ Syslog.prototype.severities = {
   'emergency': 0,
   'emerg':     0,
   'alert':     1,
-  'critical':  1,
+  'critical':  2,
   'crit':      2,
   'error':     3,
   'err':       3,


### PR DESCRIPTION
The actual severity level for 'critical' is **2**, not **1**. The 'crit' level is correctly defined as **2**.

Source: http://en.wikipedia.org/wiki/Syslog#Severity_levels
