### PR TITLE
Expose severity level in the emitted event

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ syslog.write('Message to syslog', 'utf8', function() {
 syslog.info('find me in the logs');
 syslog.warn('Streams are too cool');
 syslog.error('Red alert');
+
+// Listen for log events
+syslog.on('log', function(message, severity) {
+  // Do something with message or severity
+  // severity is 3 because you called .error below
+});
+syslog.error('something bad happened');
 ```
 
 ## Test

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ Syslog.prototype._write = function(chunk, encoding, callback) {
 
 Syslog.prototype.log = function(severity, message) {
   syslog.write(this.severities[severity], message);
-  this.emit('log', message);
+  this.emit('log', message, this.severities[severity]);
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -46,4 +46,14 @@ describe('Syslog', function() {
       done();
     });
   });
+
+  it('should expose severity in the emitted event', function (done) {
+    var logger = new (require('..'));
+    logger.on('log', function(message, severity) {
+      should.exist(severity);
+      severity.should.equal(7);
+      done();
+    });
+    logger.log('debug', 'testing log event');
+  });
 });


### PR DESCRIPTION
Having the severity included allows me to filter through the emitted events and acting only on those I need to act on.

Also great for CLI applications where only messages above a specific severity level should be printed on-screen during execution.

Tests provided, README updated, code style and backwards-compatibility maintained. Thanks for merging and releasing to NPM!
